### PR TITLE
Use NumPy inputs/outputs for weighted Delaunay edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 Extraction rapide du **1‑squelette** de la triangulation régulière 3D (Delaunay pondéré) avec **CGAL**.
 
-- **Entrée**: `.xyzw` où chaque ligne contient `x y z w` (float). `w` est le **poids de puissance** de CGAL (si vous pensez en rayon `r`, utilisez `w = r^2`).
-- **Sortie**: texte, une ligne par arête finie: `i j` (indices 0‑based des points).
+- **Entrée**: deux fichiers binaires `.npy` :
+  - `points.npy` de taille `(N,3)` contenant les coordonnées 3D.
+  - `weights.npy` de taille `(N,)` contenant les poids de puissance (`w = r^2`).
+- **Sortie**: `edges.npy`, tableau `(M,2)` d'indices `uint32` triés des arêtes finies.
 
 ## Dépendances (Ubuntu 22.04/24.04)
 ```bash
@@ -20,13 +22,14 @@ cmake --build build -j
 
 ## Utilisation
 ```bash
-./build/EdgesCGALWeightedDelaunay3D data/example.xyzw out.edges
+./build/EdgesCGALWeightedDelaunay3D points.npy weights.npy out_edges.npy
 # Parallélisme (si TBB trouvé + tbbmalloc présent) :
-CGAL_NTHREADS=$(nproc) ./build/EdgesCGALWeightedDelaunay3D data/example.xyzw out.edges
+CGAL_NTHREADS=$(nproc) ./build/EdgesCGALWeightedDelaunay3D points.npy weights.npy out_edges.npy
 ```
 
 ## Données de test
 `data/example.xyzw` contient 1000 points uniformes dans `[0,1]^3` avec des poids plausibles (`w=r^2`, `r~U(0,0.02)`).
+Pour l'utiliser avec le nouveau format, convertissez-le au préalable en `.npy`.
 
 ## Remarques
 - Si `tbb` est trouvé **sans** `tbbmalloc`, le build **désactive** la voie parallèle pour éviter les erreurs de linkage (`scalable_*`).  


### PR DESCRIPTION
## Summary
- switch CLI to accept separate `points.npy` and `weights.npy` inputs and write edges as `edges.npy`
- implement lightweight NumPy `.npy` reader/writer for double and uint32 arrays
- update README with new usage instructions

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j`
- `./build/EdgesCGALWeightedDelaunay3D test_pts.npy test_w.npy out_edges.npy`

------
https://chatgpt.com/codex/tasks/task_b_68c706dd3e288326900cfd4502739793